### PR TITLE
Ovid/opal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 js/
+pkg*

--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ Is it Perl?
     npm install
     npm run build
     npm test
+
+# Example
+
+After building, you can run the example from this directory:
+
+    ./examples/99-bottles.opal

--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ Is it Perl?
 After building, you can run the example from this directory:
 
     ./examples/99-bottles.opal
+    ./bin/opal examples/99-bottles.opal
+    ./bin/opal -e 'say "Hello, world!";'

--- a/README.md
+++ b/README.md
@@ -22,3 +22,35 @@ After building, you can run the example from this directory:
     ./examples/99-bottles.opal
     ./bin/opal examples/99-bottles.opal
     ./bin/opal -e 'say "Hello, world!";'
+
+# Installation
+
+To install opal as a standalone executable, you can use `pkg` to bundle it into
+a single file for your platform.
+
+First, install `pkg` if you haven’t already:
+
+    npm install -g pkg
+
+Then build the binary:
+
+    pkg . --targets <target> --output ~/bin/opal
+    chmod +x ~/bin/opal
+
+Where `<target>` is one of:
+
+| Platform              | Target Name          |
+| --------------------- | -------------------- |
+| macOS (Apple Silicon) | `node18-macos-arm64` |
+| macOS (Intel)         | `node18-macos-x64`   |
+| Linux (x86\_64)       | `node18-linux-x64`   |
+| Linux (ARM)           | `node18-linux-arm64` |
+| Windows (x64)         | `node18-win-x64`     |
+
+(You can also cross-compile if you're on one OS and need a binary for another.)
+
+Once built, the file at `~/bin/opal` can now be used directly in your scripts:
+
+	#!/usr/bin/env opal
+
+	say "Hello, World! (from Opal)";

--- a/bin/opal
+++ b/bin/opal
@@ -14,24 +14,34 @@ const opalPath = path.resolve(__dirname, '../js/src/Opal.js');
 // Import Opal using the absolute path
 const { Opal } = await import(opalPath);
 
-const file = process.argv[2];
+const args = process.argv.slice(2);
+const opal = new Opal({ quiet: true });
 
-if (!file) {
-    console.error('Please provide a file to run.');
+if (args.length === 0) {
+    console.error('Please provide a file to run, or use the -e flag to execute code.');
     process.exit(1);
 }
 
-fs.readFile(file, 'utf8', (err, data) => {
-    if (err) {
-        console.error(`Error reading file: ${err.message}`);
+if (args[0] === '-e') {
+    const code = args[1];
+    if (!code) {
+        console.error('Error: -e requires an argument');
         process.exit(1);
     }
+    opal.run([code]);
+} else {
+    const file = args[0];
+    fs.readFile(file, 'utf8', (err, data) => {
+        if (err) {
+            console.error(`Error reading file: ${err.message}`);
+            process.exit(1);
+        }
 
-    const lines = data.split('\n');
-    if (lines[0].startsWith('#!')) {
-        lines.shift();
-    }
+        const lines = data.split('\n');
+        if (lines[0].startsWith('#!')) {
+            lines.shift();
+        }
 
-    const opal = new Opal({ quiet: true });
-    opal.run(lines);
-});
+        opal.run(lines);
+    });
+}

--- a/bin/opal
+++ b/bin/opal
@@ -32,6 +32,6 @@ fs.readFile(file, 'utf8', (err, data) => {
         lines.shift();
     }
 
-    const opal = new Opal({ quiet: false });
+    const opal = new Opal({ quiet: true });
     opal.run(lines);
 });

--- a/bin/opal
+++ b/bin/opal
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+// Get the directory name of the current module
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Construct an absolute path to Opal.js
+const opalPath = path.resolve(__dirname, '../js/src/Opal.js');
+
+// Import Opal using the absolute path
+const { Opal } = await import(opalPath);
+
+const file = process.argv[2];
+
+if (!file) {
+    console.error('Please provide a file to run.');
+    process.exit(1);
+}
+
+fs.readFile(file, 'utf8', (err, data) => {
+    if (err) {
+        console.error(`Error reading file: ${err.message}`);
+        process.exit(1);
+    }
+
+    const lines = data.split('\n');
+    if (lines[0].startsWith('#!')) {
+        lines.shift();
+    }
+
+    const opal = new Opal({ quiet: false });
+    opal.run(lines);
+});

--- a/bin/opal
+++ b/bin/opal
@@ -1,18 +1,8 @@
 #!/usr/bin/env node
 
-import * as fs from 'fs';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
-
-// Get the directory name of the current module
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-// Construct an absolute path to Opal.js
-const opalPath = path.resolve(__dirname, '../js/src/Opal.js');
-
-// Import Opal using the absolute path
-const { Opal } = await import(opalPath);
+const fs = require('fs');
+const path = require('path');
+const { Opal } = require('../js/src/Opal.js');
 
 const args = process.argv.slice(2);
 const opal = new Opal({ quiet: true });

--- a/example.opal
+++ b/example.opal
@@ -1,3 +1,28 @@
 #!/usr/bin/env /Users/ovid/projects/perl/pp/bin/opal
 
-say "Hello from Opal!";
+my $num = 99;
+while ($num > 0) {
+
+    my $s = '';
+    unless ($num == 1) {
+        $s = 's';
+    }
+
+    say $num . " bottle" . $s . " of beer on the wall, " . $num . " bottle" . $s . " of beer";
+
+    $num = $num - 1;
+
+    unless ($num == 1) {
+        $s = 's';
+    }
+
+    if ($num == 0) {
+        say "No more";
+    } else {
+        say "Take one down, pass it around, " . $num . " bottle" . $s . " of beer on the wall";
+    }
+}
+
+say "No more bottles of beer on the wall, no more bottles of beer.";
+say "Go to the store and buy some more, 99 bottles of beer on the wall.";
+

--- a/example.opal
+++ b/example.opal
@@ -1,0 +1,3 @@
+#!/usr/bin/env /Users/ovid/projects/perl/pp/bin/opal
+
+say "Hello from Opal!";

--- a/examples/99-bottles.opal
+++ b/examples/99-bottles.opal
@@ -1,4 +1,4 @@
-#!/usr/bin/env /Users/ovid/projects/perl/pp/bin/opal
+#!/usr/bin/env bin/opal
 
 my $num = 99;
 while ($num > 0) {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,9 @@
 {
+  "name": "opal-cli",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "main": "bin/opal",
+  "bin": "bin/opal",
   "devDependencies": {
     "@types/node": "^22.13.17",
     "typescript": "^5.5.2"
@@ -7,6 +12,17 @@
     "build": "rm -rf ./js && tsc",
     "test": "tsc && node --test js/tests/*.test.js",
     "parser-test": "tsc && node --test js/tests/*-Parser.test.js",
-    "parser-devel": "tsc && node --test js/tests/999-Parser.playground.js"
+    "parser-devel": "tsc && node --test js/tests/999-Parser.playground.js",
+    "package": "pkg . --out-path dist/"
+  },
+  "pkg": {
+    "assets": [
+      "js/src/**/*"
+    ],
+    "targets": [
+      "node18-linux-x64",
+      "node18-macos-x64",
+      "node18-win-x64"
+    ]
   }
 }

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -9,8 +9,6 @@ import {
 
 import { InstructionSet, loadInstructionSet } from './Compiler/InstructionSet'
 import { OpTreeEmitter } from './Compiler/OpTreeEmitter'
-import { Program } from './Parser/AST'
-import { OpTree } from './Runtime/API'
 
 export class Compiler {
     public config  : CompilerConfig;

--- a/src/Runtime.ts
+++ b/src/Runtime.ts
@@ -339,10 +339,8 @@ export class Thread {
         if (this.config.DEBUG) {
             console.log('\x1b[44m  STDOUT ▶ :\x1b[45m', args.map((pv) => pv.value).join(''), '\x1b[0m');
         } else {
-            if (!this.config.QUIET) {
-                // FIXME: this should use stdout
-                console.log(args.map((pv) => pv.value).join(''));
-            }
+            // FIXME: this should use stdout
+            console.log(args.map((pv) => pv.value).join(''));
         }
     }
 


### PR DESCRIPTION
* Small script in `examples/` to use a shebang
* You can run `./bin/opal -e 'say "Hello, world!";'` from the command line
* You can now use `pkg` to install opal as a standalone in `~/bin/opal`
* Altered `src/Runtime.ts` to ensure that I could separate "quiet" output from STDOUT in a script. (FIXME comment still there because I'm unsure it's the right fix)

Bug: Note that the trailing semicolon is needed after "Hello, World!":

```
06:52:59 (ovid/opal) ~/projects/perl/pp $ bin/opal -e 'say "Hello, World!"'
/Users/ovid/projects/perl/pp/js/src/Runtime.js:210
                throw new Error(`Unlinked OP, no opcode (${op.name} = ${JSON.stringify(op.config)})`);
                      ^

Error: Unlinked OP, no opcode (list = {})
    at Thread.run (/Users/ovid/projects/perl/pp/js/src/Runtime.js:210:23)
    at Interpreter.run (/Users/ovid/projects/perl/pp/js/src/Interpreter.js:26:19)
    at Opal.run (/Users/ovid/projects/perl/pp/js/src/Opal.js:131:26)
    at file:///Users/ovid/projects/perl/pp/bin/opal:31:10

Node.js v23.3.0
```